### PR TITLE
POC: Use the managed identity capz-controller uses when handling the local cluster DNS resources

### DIFF
--- a/azure/services/dns/client.go
+++ b/azure/services/dns/client.go
@@ -30,7 +30,11 @@ type azureClient struct {
 var _ client = (*azureClient)(nil)
 
 func newAzureClient(azureCluster *v1beta1.AzureCluster) (*azureClient, error) {
-	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	// Hardcode the CAPZ IDentity for testing
+	resourceID := azidentity.ResourceID("/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourcegroups/garlic/providers/Microsoft.ManagedIdentity/userAssignedIdentities/garlic-capz")
+	opts = azidentity.ManagedIdentityCredentialOptions{ID: resourceID}
+	cred, err = azidentity.NewManagedIdentityCredential(&opts)
+	//cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/azure/services/dns/client.go
+++ b/azure/services/dns/client.go
@@ -32,8 +32,8 @@ var _ client = (*azureClient)(nil)
 func newAzureClient(azureCluster *v1beta1.AzureCluster) (*azureClient, error) {
 	// Hardcode the CAPZ IDentity for testing
 	resourceID := azidentity.ResourceID("/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourcegroups/garlic/providers/Microsoft.ManagedIdentity/userAssignedIdentities/garlic-capz")
-	opts = azidentity.ManagedIdentityCredentialOptions{ID: resourceID}
-	cred, err = azidentity.NewManagedIdentityCredential(&opts)
+	opts := azidentity.ManagedIdentityCredentialOptions{ID: resourceID}
+	cred, err := azidentity.NewManagedIdentityCredential(&opts)
 	//cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -61,8 +61,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.Info("Reconcile DNS", "DNSZone", clusterZoneName)
 
 	// create DNS Zone
-	log.Info("FC TEST", "ClusterRecordSet Fetching ", s.scope.ResourceGroup(), clusterZoneName)
-	log.Info("FC TEST", "ClusterRecordSet Credentials ", s.azureClient)
+	log.Info(fmt.Sprintf("ClusterRecordSet fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName))
+	log.Info(fmt.Sprintf("ClusterRecordSet Credentials %s", s.azureClient))
 	clusterRecordSets, err := s.azureClient.ListRecordSets(ctx, s.scope.ResourceGroup(), clusterZoneName)
 	if err != nil && !azure.IsParentResourceNotFound(err) {
 		return microerror.Mask(err)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"github.com/Azure/go-autorest/autorest/to"

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -62,8 +62,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.Info("Reconcile DNS", "DNSZone", clusterZoneName)
 
 	// create DNS Zone
-	log.Info(fmt.Sprintf("ClusterRecordSet fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName))
-	log.Info(fmt.Sprintf("ClusterRecordSet Credentials %v", s.azureClient))
 	clusterRecordSets, err := s.azureClient.ListRecordSets(ctx, s.scope.ResourceGroup(), clusterZoneName)
 	if err != nil && !azure.IsParentResourceNotFound(err) {
 		return microerror.Mask(err)
@@ -73,7 +71,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			return microerror.Mask(err)
 		}
 	}
-	log.Info("ClusterRecordSet Fetched")
 
 	// get cluster specific zone information
 	clusterZone, err := s.azureClient.GetZone(ctx, s.scope.ResourceGroup(), clusterZoneName)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -61,8 +61,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.Info("Reconcile DNS", "DNSZone", clusterZoneName)
 
 	// create DNS Zone
-	log.Info("ClusterRecordSet Fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName)
-	log.Info("ClusterRecordSet Credentials %v", s.azureClient)
+	log.Info("FC TEST", "ClusterRecordSet Fetching ", s.scope.ResourceGroup(), clusterZoneName)
+	log.Info("FC TEST", "ClusterRecordSet Credentials ", s.azureClient)
 	clusterRecordSets, err := s.azureClient.ListRecordSets(ctx, s.scope.ResourceGroup(), clusterZoneName)
 	if err != nil && !azure.IsParentResourceNotFound(err) {
 		return microerror.Mask(err)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -62,8 +62,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.Info("Reconcile DNS", "DNSZone", clusterZoneName)
 
 	// create DNS Zone
-	log.Info(fmt.Sprintf("ClusterRecordSet fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName))
-	log.Info(fmt.Sprintf("ClusterRecordSet Credentials %s", s.azureClient))
+	//log.Info(fmt.Sprintf("ClusterRecordSet fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName))
+	//log.Info(fmt.Sprintf("ClusterRecordSet Credentials %s", s.azureClient))
 	clusterRecordSets, err := s.azureClient.ListRecordSets(ctx, s.scope.ResourceGroup(), clusterZoneName)
 	if err != nil && !azure.IsParentResourceNotFound(err) {
 		return microerror.Mask(err)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -62,8 +62,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.Info("Reconcile DNS", "DNSZone", clusterZoneName)
 
 	// create DNS Zone
-	//log.Info(fmt.Sprintf("ClusterRecordSet fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName))
-	//log.Info(fmt.Sprintf("ClusterRecordSet Credentials %s", s.azureClient))
+	log.Info(fmt.Sprintf("ClusterRecordSet fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName))
+	log.Info(fmt.Sprintf("ClusterRecordSet Credentials %v", s.azureClient))
 	clusterRecordSets, err := s.azureClient.ListRecordSets(ctx, s.scope.ResourceGroup(), clusterZoneName)
 	if err != nil && !azure.IsParentResourceNotFound(err) {
 		return microerror.Mask(err)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -72,6 +72,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			return microerror.Mask(err)
 		}
 	}
+	log.Info("ClusterRecordSet Fetched")
 
 	// get cluster specific zone information
 	clusterZone, err := s.azureClient.GetZone(ctx, s.scope.ResourceGroup(), clusterZoneName)

--- a/azure/services/dns/dns.go
+++ b/azure/services/dns/dns.go
@@ -61,6 +61,8 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.Info("Reconcile DNS", "DNSZone", clusterZoneName)
 
 	// create DNS Zone
+	log.Info("ClusterRecordSet Fetching %s/%s", s.scope.ResourceGroup(), clusterZoneName)
+	log.Info("ClusterRecordSet Credentials %v", s.azureClient)
 	clusterRecordSets, err := s.azureClient.ListRecordSets(ctx, s.scope.ResourceGroup(), clusterZoneName)
 	if err != nil && !azure.IsParentResourceNotFound(err) {
 		return microerror.Mask(err)


### PR DESCRIPTION
The current implementation does not work because


`cred, err := azidentity.NewDefaultAzureCredential(nil)`

will use the environment variables we define and try tro set the same identity as the `garlic-dns-operator-azure` credentials https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash#-option-1-define-environment-variables

```
    - name: AZURE_CLIENT_ID
      valueFrom:
        secretKeyRef:
          key: clientID
          name: dns-operator-azure-azure-credentials
```

we actually need to **specify which identity we want to assume**, since the default one attached to the node (which `newDefaultAzureCredential would pick` is not priviliged enough to create dns zones in other resource groups in the same subscription. 

We **need to** use the `<MC>-capz` identity , or in general, the identity used to create the cluster and specified in `azureclusteridentity` for the given cluster we are reconciling

we could use `NewDefaultAzureCredential` only if 

* we change the name of the environment variables we export to not be the default ones ( we can still use them in `azidentity.NewClientSecretCredential` by using the alternative names ) 
* We specificy in the environment the Managed Identity we want to assume

or 

* we use `azidentity.NewManagedIdentityCredential` 

I am going to test the latter which is easier for me with hardcoded values , ideally we would fetch the information from the AzureClusterIdentity used to create the cluster 