### PR TITLE
create managedidentitycredential for cluster zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Depending on the referenced `AzureClusterIdentity` the internal `dnsClient` uses either `ManagedIdentityCredential` for MSI or `DefaultAzureCredential` for Service Principal
 - Decrease TTL for `A-Records` from 60 minutes down to 5 minutes
 
 ## [1.0.3] - 2023-03-09

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -152,9 +152,9 @@ func (r *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterSco
 	// If the AzureCluster doesn't has our finalizer, add it.
 	if !controllerutil.ContainsFinalizer(azureCluster, AzureClusterControllerFinalizer) {
 		controllerutil.AddFinalizer(azureCluster, AzureClusterControllerFinalizer)
-		// Register the finalizer immediately to avoid orphaning cluster resources on delete
-		if err := r.Update(ctx, azureCluster); err != nil {
-			return reconcile.Result{}, microerror.Mask(err)
+		// Register the finalizer immediately to avoid orphaning Azure resources on delete
+		if err := clusterScope.PatchObject(ctx); err != nil {
+			return reconcile.Result{}, err
 		}
 	}
 

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	capzscope "sigs.k8s.io/cluster-api-provider-azure/azure/scope"
@@ -167,10 +168,50 @@ func (r *AzureClusterReconciler) reconcileNormal(ctx context.Context, clusterSco
 	// Reconcile workload cluster DNS records
 	publicIPsService := publicips.New(clusterScope)
 
+	azureClusterIdentity := &capz.AzureClusterIdentity{}
+	log.V(1).Info(fmt.Sprintf("try to get the clusterClusterIdentity - %s", clusterScope.AzureCluster.Spec.IdentityRef.Name))
+
+	err = r.Client.Get(ctx, types.NamespacedName{
+		Name:      clusterScope.AzureCluster.Spec.IdentityRef.Name,
+		Namespace: clusterScope.AzureCluster.Spec.IdentityRef.Namespace,
+	}, azureClusterIdentity)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("cluster object was not found", "error", err)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, microerror.Mask(err)
+	}
+
+	log.V(1).Info("azureClusterIdentity information",
+		"spec.Type", azureClusterIdentity.Spec.Type,
+		"spec.tenantID", azureClusterIdentity.Spec.TenantID,
+		"spec.clientID", azureClusterIdentity.Spec.TenantID,
+	)
+
+	staticServicePrincipalSecret := &corev1.Secret{}
+	if azureClusterIdentity.Spec.Type == capz.ManualServicePrincipal {
+		log.V(1).Info(fmt.Sprintf("try to get the referenced secret - %s/%s", azureClusterIdentity.Spec.ClientSecret.Namespace, azureClusterIdentity.Spec.ClientSecret.Name))
+
+		err = r.Client.Get(ctx, types.NamespacedName{
+			Name:      azureClusterIdentity.Spec.ClientSecret.Name,
+			Namespace: azureClusterIdentity.Spec.ClientSecret.Namespace,
+		}, staticServicePrincipalSecret)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.V(1).Info("static service principal secret object was not found", "error", err)
+				return reconcile.Result{}, nil
+			}
+			return reconcile.Result{}, microerror.Mask(err)
+		}
+	}
+
 	params := scope.DNSScopeParams{
-		ClusterScope:            *clusterScope,
-		BaseDomain:              r.BaseDomain,
-		BaseDomainResourceGroup: r.BaseDomainResourceGroup,
+		ClusterScope:                       *clusterScope,
+		AzureClusterIdentity:               *azureClusterIdentity,
+		AzureClusterServicePrincipalSecret: *staticServicePrincipalSecret,
+		BaseDomain:                         r.BaseDomain,
+		BaseDomainResourceGroup:            r.BaseDomainResourceGroup,
 		BaseZoneCredentials: scope.BaseZoneCredentials{
 			ClientID:       r.BaseZoneClientID,
 			ClientSecret:   r.BaseZoneClientSecret,

--- a/controllers/azuremachine_controller.go
+++ b/controllers/azuremachine_controller.go
@@ -164,8 +164,8 @@ func (r *AzureMachineReconciler) reconcileNormal(ctx context.Context, azureMachi
 	if !controllerutil.ContainsFinalizer(azureMachineScope.AzureMachine, AzureMachineControllerFinalizer) {
 		controllerutil.AddFinalizer(azureMachineScope.AzureMachine, AzureMachineControllerFinalizer)
 		// Register the finalizer immediately to avoid orphaning cluster resources on delete
-		if err := r.Update(ctx, azureMachineScope.AzureMachine); err != nil {
-			return reconcile.Result{}, microerror.Mask(err)
+		if err := azureMachineScope.PatchObject(ctx); err != nil {
+			return reconcile.Result{}, err
 		}
 	}
 


### PR DESCRIPTION
towards: https://github.com/giantswarm/roadmap/issues/1919


tested by 

* deleting the entire `garlic.azuretest.gigantic.io` DNS zone and the NS-Record for `garlic` in `azuretest.gigantic.io`

  ```
  I0323 19:22:57.845036       1 request.go:682] Waited for 1.038054023s due to client-side throttling, not priority and fairness, request: GET:https://172.31.0.1:443/apis/kyverno.io/v1?timeout=32s
  2023-03-23T19:22:59Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
  2023-03-23T19:22:59Z	INFO	setup	starting manager
  2023-03-23T19:22:59Z	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
  2023-03-23T19:22:59Z	INFO	Starting EventSource	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "source": "kind source: *v1beta1.AzureMachine"}
  2023-03-23T19:22:59Z	INFO	Starting Controller	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine"}
  2023-03-23T19:22:59Z	INFO	Starting EventSource	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "source": "kind source: *v1beta1.AzureCluster"}
  2023-03-23T19:22:59Z	INFO	Starting Controller	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster"}
  2023-03-23T19:22:59Z	INFO	Starting workers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "worker count": 5}
  2023-03-23T19:22:59Z	INFO	Starting workers	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "worker count": 5}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-dkxdb","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-dkxdb", "reconcileID": "ff3feebf-cc03-4f7e-a94f-29edc3b03c76"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-h6wns","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-h6wns", "reconcileID": "c7da3963-1faf-4350-964b-f1b7911f498d"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-szd2z","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-szd2z", "reconcileID": "108b04f1-e3fa-4599-ad19-9b8dabe9e9dd"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-qhh4w","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-qhh4w", "reconcileID": "16e57d25-89e2-4ef8-914d-b6a65ffcc420"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-6fckc","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-6fckc", "reconcileID": "0e2d9e4d-209d-4a51-97a1-7bdc1f92492a"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-dkxdb","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-dkxdb", "reconcileID": "ff3feebf-cc03-4f7e-a94f-29edc3b03c76", "machine": "garlic-md00-3bfe5047-dkxdb"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-szd2z","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-szd2z", "reconcileID": "108b04f1-e3fa-4599-ad19-9b8dabe9e9dd", "machine": "garlic-control-plane-0bc841f3-szd2z"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-6fckc","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-6fckc", "reconcileID": "0e2d9e4d-209d-4a51-97a1-7bdc1f92492a", "machine": "garlic-control-plane-0bc841f3-6fckc"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-gdtl2","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-gdtl2", "reconcileID": "a8e77e38-0ec3-4317-9b99-c7e8deedc2e1"}
  2023-03-23T19:22:59Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:22:59Z	DEBUG	try to get the clusterClusterIdentity - cluster-identity	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:22:59Z	DEBUG	bastion host annotation is not empty	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:22:59Z	INFO	azure-dns-create	Reconcile DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io"}
  2023-03-23T19:22:59Z	DEBUG	azure-dns-create	client information for base Zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "clientID": "72d1dffd-21d9-47a5-bc1a-f6aaeff1ecdf", "tenantID": "31f75bf9-3d8c-4691-95c0-83dd71613db8", "subscriptionID": "1be3b2e6-497b-45b9-915f-eb35cae23c6a"}
  2023-03-23T19:22:59Z	DEBUG	azure-dns-create	client information for cluster Zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "clientID": "27f41149-3149-4588-aee9-61ce76cbe552", "tenantID": "74ec60c4-8b11-486b-b259-993fb4f19747", "subscriptionID": "5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-qhh4w","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-qhh4w", "reconcileID": "16e57d25-89e2-4ef8-914d-b6a65ffcc420", "machine": "garlic-md00-3bfe5047-qhh4w"}
  2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-blf8v","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-blf8v", "reconcileID": "6edd8dce-54ab-47e4-b24e-d399870b723d"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-h6wns","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-h6wns", "reconcileID": "c7da3963-1faf-4350-964b-f1b7911f498d", "machine": "garlic-md00-3bfe5047-h6wns"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-blf8v","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-blf8v", "reconcileID": "6edd8dce-54ab-47e4-b24e-d399870b723d", "machine": "garlic-control-plane-0bc841f3-blf8v"}
  2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-gdtl2","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-gdtl2", "reconcileID": "a8e77e38-0ec3-4317-9b99-c7e8deedc2e1", "machine": "garlic-md00-3bfe5047-gdtl2"}
  2023-03-23T19:22:59Z	DEBUG	machine has NetworkInterfacesReady condition	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd", "machine": "garlic-bastion-c3ff8b65-77z7b"}
  2023-03-23T19:22:59Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd"}
  2023-03-23T19:22:59Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd"}
  2023-03-23T19:22:59Z	DEBUG	azure-dns-create	cluster specific DNS zone not found	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "error": "GET https://management.azure.com/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnsZones/garlic.azuretest.gigantic.io/recordsets\n--------------------------------------------------------------------------------\nRESPONSE 404: 404 Not Found\nERROR CODE: ParentResourceNotFound\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"ParentResourceNotFound\",\n    \"message\": \"Can not perform requested operation on nested resource. Parent resource 'garlic.azuretest.gigantic.io' not found.\"\n  }\n}\n--------------------------------------------------------------------------------\n"}
  2023-03-23T19:22:59Z	INFO	Creating DNS zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "zone": "garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:02Z	INFO	Successfully created DNS zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "zone": "garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:02Z	DEBUG	azure-dns-create	get cluster specific zone information	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:02Z	DEBUG	azure-dns-create	list NS records in basedomain	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "resourcegroup": "root_dns_zone_rg", "dns zone": "azuretest.gigantic.io"}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	range over received NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	basedomainRecordSet	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name": "@"}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	basedomainRecordSet	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name": "@"}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	basedomainRecordSet	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name": "glippy"}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	range over clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns1-03.azure-dns.com."}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns2-03.azure-dns.net."}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns3-03.azure-dns.org."}
  2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns4-03.azure-dns.info."}
  2023-03-23T19:23:03Z	INFO	azure-dns-create	Creating NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "NSrecord": "garlic", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T19:23:04Z	INFO	azure-dns-create	Successfully created NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "NSrecord": "garlic", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T19:23:04Z	DEBUG	arecords	update A records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "current record sets": null}
  2023-03-23T19:23:04Z	DEBUG	getIPAddressForPublicDNS	resolve IP for pip-garlic-apiserver/garlic-8dc279ea.westeurope.cloudapp.azure.com	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:04Z	DEBUG	getIPAddressForPublicDNS	got IP 20.31.78.215 for pip-garlic-apiserver/garlic-8dc279ea.westeurope.cloudapp.azure.com	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - api	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - apiserver	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - bastion	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - bastion1	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  2023-03-23T19:23:04Z	DEBUG	arecords	update A records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "records to create": [{"name":"api","properties":{"ARecords":[{"ipv4Address":"20.31.78.215"}],"TTL":300},"type":"A"},{"name":"apiserver","properties":{"ARecords":[{"ipv4Address":"20.31.78.215"}],"TTL":300},"type":"A"},{"name":"bastion","properties":{"ARecords":[{"ipv4Address":"10.223.16.135"}],"TTL":300},"type":"A"},{"name":"bastion1","properties":{"ARecords":[{"ipv4Address":"10.223.16.135"}],"TTL":300},"type":"A"}]}
  2023-03-23T19:23:04Z	INFO	arecords	DNS A record api is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "api.garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:04Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "api", "ipv4": [{"ipv4Address":"20.31.78.215"}]}
  2023-03-23T19:23:05Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "api", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/api"}
  2023-03-23T19:23:05Z	INFO	arecords	DNS A record apiserver is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "apiserver.garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:05Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "apiserver", "ipv4": [{"ipv4Address":"20.31.78.215"}]}
  2023-03-23T19:23:06Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "apiserver", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/apiserver"}
  2023-03-23T19:23:06Z	INFO	arecords	DNS A record bastion is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "bastion.garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:06Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion", "ipv4": [{"ipv4Address":"10.223.16.135"}]}
  2023-03-23T19:23:07Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/bastion"}
  2023-03-23T19:23:07Z	INFO	arecords	DNS A record bastion1 is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "bastion1.garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:07Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion1", "ipv4": [{"ipv4Address":"10.223.16.135"}]}
  2023-03-23T19:23:08Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion1", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/bastion1"}
  2023-03-23T19:23:08Z	INFO	azure-dns-create	Successfully reconciled DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io"}
  2023-03-23T19:23:08Z	INFO	Successfully reconciled AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
  ```

* creating a WC in `garlic` by using this cluster-config
  ```yaml
  apiVersion: v1
  data:
    values: |
      metadata:
        name: "mario01"
        description: "mario01 test cluster"
        organization: "multi-project"
  
      providerSpecific:
        location: "westeurope"
        #This is the GHOST subscription
        #subscriptionId: 6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3
        subscriptionId: 5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8
  
      nodePools:
      - name: md00
        instanceType: Standard_D2s_v5
        replicas: 3
        rootVolumeSizeGB: 50
      internal:
        identity:
          type: UserAssigned
          attachCapzControllerUserAssignedIdentity: true
  ```

    ```
    I0323 19:22:57.845036       1 request.go:682] Waited for 1.038054023s due to client-side throttling, not priority and fairness, request: GET:https://172.31.0.1:443/apis/kyverno.io/v1?timeout=32s
    2023-03-23T19:22:59Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
    2023-03-23T19:22:59Z	INFO	setup	starting manager
    2023-03-23T19:22:59Z	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
    2023-03-23T19:22:59Z	INFO	Starting EventSource	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "source": "kind source: *v1beta1.AzureMachine"}
    2023-03-23T19:22:59Z	INFO	Starting Controller	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine"}
    2023-03-23T19:22:59Z	INFO	Starting EventSource	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "source": "kind source: *v1beta1.AzureCluster"}
    2023-03-23T19:22:59Z	INFO	Starting Controller	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster"}
    2023-03-23T19:22:59Z	INFO	Starting workers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "worker count": 5}
    2023-03-23T19:22:59Z	INFO	Starting workers	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "worker count": 5}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-dkxdb","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-dkxdb", "reconcileID": "ff3feebf-cc03-4f7e-a94f-29edc3b03c76"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-h6wns","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-h6wns", "reconcileID": "c7da3963-1faf-4350-964b-f1b7911f498d"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-szd2z","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-szd2z", "reconcileID": "108b04f1-e3fa-4599-ad19-9b8dabe9e9dd"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-qhh4w","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-qhh4w", "reconcileID": "16e57d25-89e2-4ef8-914d-b6a65ffcc420"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-6fckc","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-6fckc", "reconcileID": "0e2d9e4d-209d-4a51-97a1-7bdc1f92492a"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-dkxdb","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-dkxdb", "reconcileID": "ff3feebf-cc03-4f7e-a94f-29edc3b03c76", "machine": "garlic-md00-3bfe5047-dkxdb"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-szd2z","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-szd2z", "reconcileID": "108b04f1-e3fa-4599-ad19-9b8dabe9e9dd", "machine": "garlic-control-plane-0bc841f3-szd2z"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-6fckc","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-6fckc", "reconcileID": "0e2d9e4d-209d-4a51-97a1-7bdc1f92492a", "machine": "garlic-control-plane-0bc841f3-6fckc"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-gdtl2","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-gdtl2", "reconcileID": "a8e77e38-0ec3-4317-9b99-c7e8deedc2e1"}
    2023-03-23T19:22:59Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:22:59Z	DEBUG	try to get the clusterClusterIdentity - cluster-identity	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:22:59Z	DEBUG	bastion host annotation is not empty	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:22:59Z	INFO	azure-dns-create	Reconcile DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io"}
    2023-03-23T19:22:59Z	DEBUG	azure-dns-create	client information for base Zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "clientID": "72d1dffd-21d9-47a5-bc1a-f6aaeff1ecdf", "tenantID": "31f75bf9-3d8c-4691-95c0-83dd71613db8", "subscriptionID": "1be3b2e6-497b-45b9-915f-eb35cae23c6a"}
    2023-03-23T19:22:59Z	DEBUG	azure-dns-create	client information for cluster Zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "clientID": "27f41149-3149-4588-aee9-61ce76cbe552", "tenantID": "74ec60c4-8b11-486b-b259-993fb4f19747", "subscriptionID": "5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-qhh4w","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-qhh4w", "reconcileID": "16e57d25-89e2-4ef8-914d-b6a65ffcc420", "machine": "garlic-md00-3bfe5047-qhh4w"}
    2023-03-23T19:22:59Z	DEBUG	try to get the cluster - garlic	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-blf8v","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-blf8v", "reconcileID": "6edd8dce-54ab-47e4-b24e-d399870b723d"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-h6wns","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-h6wns", "reconcileID": "c7da3963-1faf-4350-964b-f1b7911f498d", "machine": "garlic-md00-3bfe5047-h6wns"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-control-plane-0bc841f3-blf8v","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-control-plane-0bc841f3-blf8v", "reconcileID": "6edd8dce-54ab-47e4-b24e-d399870b723d", "machine": "garlic-control-plane-0bc841f3-blf8v"}
    2023-03-23T19:22:59Z	DEBUG	machine doesn't met required conditions and labels	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-md00-3bfe5047-gdtl2","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-md00-3bfe5047-gdtl2", "reconcileID": "a8e77e38-0ec3-4317-9b99-c7e8deedc2e1", "machine": "garlic-md00-3bfe5047-gdtl2"}
    2023-03-23T19:22:59Z	DEBUG	machine has NetworkInterfacesReady condition	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd", "machine": "garlic-bastion-c3ff8b65-77z7b"}
    2023-03-23T19:22:59Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd"}
    2023-03-23T19:22:59Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"garlic-bastion-c3ff8b65-77z7b","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic-bastion-c3ff8b65-77z7b", "reconcileID": "e2eee4e7-147b-4857-997f-c9838a24bbcd"}
    2023-03-23T19:22:59Z	DEBUG	azure-dns-create	cluster specific DNS zone not found	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "error": "GET https://management.azure.com/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnsZones/garlic.azuretest.gigantic.io/recordsets\n--------------------------------------------------------------------------------\nRESPONSE 404: 404 Not Found\nERROR CODE: ParentResourceNotFound\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"ParentResourceNotFound\",\n    \"message\": \"Can not perform requested operation on nested resource. Parent resource 'garlic.azuretest.gigantic.io' not found.\"\n  }\n}\n--------------------------------------------------------------------------------\n"}
    2023-03-23T19:22:59Z	INFO	Creating DNS zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "zone": "garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:02Z	INFO	Successfully created DNS zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "zone": "garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:02Z	DEBUG	azure-dns-create	get cluster specific zone information	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:02Z	DEBUG	azure-dns-create	list NS records in basedomain	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "resourcegroup": "root_dns_zone_rg", "dns zone": "azuretest.gigantic.io"}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	range over received NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	basedomainRecordSet	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name": "@"}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	basedomainRecordSet	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name": "@"}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	basedomainRecordSet	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name": "glippy"}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	range over clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns1-03.azure-dns.com."}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns2-03.azure-dns.net."}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns3-03.azure-dns.org."}
    2023-03-23T19:23:03Z	DEBUG	azure-dns-create	clusterZone name servers	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "name server": "ns4-03.azure-dns.info."}
    2023-03-23T19:23:03Z	INFO	azure-dns-create	Creating NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "NSrecord": "garlic", "DNS zone": "azuretest.gigantic.io"}
    2023-03-23T19:23:04Z	INFO	azure-dns-create	Successfully created NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "NSrecord": "garlic", "DNS zone": "azuretest.gigantic.io"}
    2023-03-23T19:23:04Z	DEBUG	arecords	update A records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "current record sets": null}
    2023-03-23T19:23:04Z	DEBUG	getIPAddressForPublicDNS	resolve IP for pip-garlic-apiserver/garlic-8dc279ea.westeurope.cloudapp.azure.com	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:04Z	DEBUG	getIPAddressForPublicDNS	got IP 20.31.78.215 for pip-garlic-apiserver/garlic-8dc279ea.westeurope.cloudapp.azure.com	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - api	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - apiserver	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - bastion	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:04Z	DEBUG	arecords	compare entries individually - bastion1	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    2023-03-23T19:23:04Z	DEBUG	arecords	update A records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "records to create": [{"name":"api","properties":{"ARecords":[{"ipv4Address":"20.31.78.215"}],"TTL":300},"type":"A"},{"name":"apiserver","properties":{"ARecords":[{"ipv4Address":"20.31.78.215"}],"TTL":300},"type":"A"},{"name":"bastion","properties":{"ARecords":[{"ipv4Address":"10.223.16.135"}],"TTL":300},"type":"A"},{"name":"bastion1","properties":{"ARecords":[{"ipv4Address":"10.223.16.135"}],"TTL":300},"type":"A"}]}
    2023-03-23T19:23:04Z	INFO	arecords	DNS A record api is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "api.garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:04Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "api", "ipv4": [{"ipv4Address":"20.31.78.215"}]}
    2023-03-23T19:23:05Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "api", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/api"}
    2023-03-23T19:23:05Z	INFO	arecords	DNS A record apiserver is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "apiserver.garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:05Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "apiserver", "ipv4": [{"ipv4Address":"20.31.78.215"}]}
    2023-03-23T19:23:06Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "apiserver", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/apiserver"}
    2023-03-23T19:23:06Z	INFO	arecords	DNS A record bastion is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "bastion.garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:06Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion", "ipv4": [{"ipv4Address":"10.223.16.135"}]}
    2023-03-23T19:23:07Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/bastion"}
    2023-03-23T19:23:07Z	INFO	arecords	DNS A record bastion1 is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "FQDN": "bastion1.garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:07Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion1", "ipv4": [{"ipv4Address":"10.223.16.135"}]}
    2023-03-23T19:23:08Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io", "hostname": "bastion1", "id": "/subscriptions/5a16b9e0-fb22-4e7e-b544-09f8ccab5dc8/resourceGroups/garlic/providers/Microsoft.Network/dnszones/garlic.azuretest.gigantic.io/A/bastion1"}
    2023-03-23T19:23:08Z	INFO	azure-dns-create	Successfully reconciled DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637", "DNSZone": "garlic.azuretest.gigantic.io"}
    2023-03-23T19:23:08Z	INFO	Successfully reconciled AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"garlic","namespace":"org-giantswarm"}, "namespace": "org-giantswarm", "name": "garlic", "reconcileID": "eb3e3ea8-3b4a-48df-8792-13819db6a637"}
    ```

* creating a WC in `glippy` by using this cluster-config
  ```yaml
  apiVersion: v1
  data:
    values: |
      metadata:
        name: "mario01"
        description: "mario01 test cluster"
        organization: "multi-project"
  
      providerSpecific:
        location: "westeurope"
        #This is the GHOST subscription
        subscriptionId: 6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3
  
      nodePools:
      - name: md00
        instanceType: Standard_D2s_v5
        replicas: 3
        rootVolumeSizeGB: 50
  ```

  ```
  2023-03-23T20:12:52Z	INFO	Cluster Controller has not yet set OwnerRef	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9dc22822-0b1c-432f-bbf3-fca613aceb2e"}
  2023-03-23T20:12:53Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-md00-3ee4c53a-p6wkd","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-md00-3ee4c53a-p6wkd", "reconcileID": "f607b169-e858-4100-a695-da4564aecebd"}
  2023-03-23T20:12:53Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "61b97f4b-d87b-40cd-9447-20f5ab8784b7"}
  2023-03-23T20:12:53Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-md00-3ee4c53a-nq42m","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-md00-3ee4c53a-nq42m", "reconcileID": "cece0152-c0ca-4551-8eac-78fd3c8eea8d"}
  2023-03-23T20:12:54Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-md00-3ee4c53a-zq8r5","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-md00-3ee4c53a-zq8r5", "reconcileID": "cdcb3175-fc0f-4c59-829a-b4a223143f02"}
  2023-03-23T20:14:28Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "25990cb4-f700-4ea1-b830-259d7f9db56e"}
  2023-03-23T20:14:28Z	ERROR	Reconciler error	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "25990cb4-f700-4ea1-b830-259d7f9db56e", "error": "Operation cannot be fulfilled on azureclusters.infrastructure.cluster.x-k8s.io \"mario01\": the object has been modified; please apply your changes to the latest version and try again"}
  2023-03-23T20:14:28Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "829c08a8-3737-4ab7-8e19-8f5f8ad23089"}
  2023-03-23T20:14:28Z	INFO	Requeuing cluster mario01 - phase Provisioning	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "829c08a8-3737-4ab7-8e19-8f5f8ad23089"}
  2023-03-23T20:14:28Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "fca459b7-d664-4999-a2af-e717271b5022"}
  2023-03-23T20:14:28Z	INFO	Requeuing cluster mario01 - phase Provisioning	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "fca459b7-d664-4999-a2af-e717271b5022"}
  2023-03-23T20:14:29Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-control-plane-265fa202-wjsfx","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-control-plane-265fa202-wjsfx", "reconcileID": "2bf52492-6eda-453e-b845-c4c625b6dc80"}
  2023-03-23T20:16:28Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e"}
  2023-03-23T20:16:28Z	INFO	azure-dns-create	Reconcile DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:28Z	INFO	Creating DNS zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "zone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:30Z	INFO	Successfully created DNS zone	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "zone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:31Z	INFO	azure-dns-create	Creating NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "NSrecord": "mario01", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T20:16:32Z	INFO	azure-dns-create	Successfully created NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "NSrecord": "mario01", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T20:16:33Z	INFO	arecords	DNS A record api is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io", "FQDN": "api.mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:33Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "api", "ipv4": [{"ipv4Address":"20.4.138.125"}]}
  2023-03-23T20:16:33Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "api", "id": "/subscriptions/6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3/resourceGroups/mario01/providers/Microsoft.Network/dnszones/mario01.azuretest.gigantic.io/A/api"}
  2023-03-23T20:16:33Z	INFO	arecords	DNS A record apiserver is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io", "FQDN": "apiserver.mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:33Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "apiserver", "ipv4": [{"ipv4Address":"20.4.138.125"}]}
  2023-03-23T20:16:34Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "apiserver", "id": "/subscriptions/6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3/resourceGroups/mario01/providers/Microsoft.Network/dnszones/mario01.azuretest.gigantic.io/A/apiserver"}
  2023-03-23T20:16:34Z	INFO	azure-dns-create	Successfully reconciled DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:34Z	INFO	Successfully reconciled AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7f252ccb-696a-492c-9996-58a4e520a01e"}
  2023-03-23T20:16:44Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "498dea32-80d7-417c-ab96-8516027c441a"}
  2023-03-23T20:16:44Z	ERROR	Reconciler error	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "498dea32-80d7-417c-ab96-8516027c441a", "error": "Operation cannot be fulfilled on azuremachines.infrastructure.cluster.x-k8s.io \"mario01-bastion-c3ff8b65-j5vmg\": the object has been modified; please apply your changes to the latest version and try again"}
  2023-03-23T20:16:45Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "38881ca9-f287-4777-a03f-fc9fd58769de"}
  2023-03-23T20:16:45Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "38881ca9-f287-4777-a03f-fc9fd58769de"}
  2023-03-23T20:16:45Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943"}
  2023-03-23T20:16:45Z	INFO	azure-dns-create	Reconcile DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:45Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "06fd38b2-692a-4495-981c-db312afbd6ce"}
  2023-03-23T20:16:45Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "06fd38b2-692a-4495-981c-db312afbd6ce"}
  2023-03-23T20:16:47Z	INFO	azure-dns-create	Creating NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943", "NSrecord": "mario01", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T20:16:48Z	INFO	azure-dns-create	Successfully created NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943", "NSrecord": "mario01", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T20:16:48Z	INFO	arecords	All DNS A records have already been created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:48Z	INFO	azure-dns-create	Successfully reconciled DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:16:48Z	INFO	Successfully reconciled AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "7ffff3e5-a81b-46af-ac0e-3aed3d341943"}
  2023-03-23T20:17:08Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-control-plane-265fa202-wbllg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-control-plane-265fa202-wbllg", "reconcileID": "8e04020a-cd70-470b-a3ae-44480addacba"}
  2023-03-23T20:17:35Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "d67849c2-b0c8-4e1c-b387-2661037a78e4"}
  2023-03-23T20:17:35Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "d67849c2-b0c8-4e1c-b387-2661037a78e4"}
  2023-03-23T20:17:35Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "6acf0745-3d29-4933-b83b-740a98a98b36"}
  2023-03-23T20:17:35Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "6acf0745-3d29-4933-b83b-740a98a98b36"}
  2023-03-23T20:17:35Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "0a2173d6-45d9-4816-b3b7-8c39c8b6a36b"}
  2023-03-23T20:17:35Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "0a2173d6-45d9-4816-b3b7-8c39c8b6a36b"}
  2023-03-23T20:17:35Z	INFO	Reconciling AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751"}
  2023-03-23T20:17:35Z	INFO	azure-dns-create	Reconcile DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:17:36Z	INFO	azure-dns-create	Creating NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "NSrecord": "mario01", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T20:17:37Z	INFO	azure-dns-create	Successfully created NS records	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "NSrecord": "mario01", "DNS zone": "azuretest.gigantic.io"}
  2023-03-23T20:17:37Z	INFO	arecords	DNS A record bastion is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io", "FQDN": "bastion.mario01.azuretest.gigantic.io"}
  2023-03-23T20:17:37Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "bastion", "ipv4": [{"ipv4Address":"10.0.0.5"}]}
  2023-03-23T20:17:38Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "bastion", "id": "/subscriptions/6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3/resourceGroups/mario01/providers/Microsoft.Network/dnszones/mario01.azuretest.gigantic.io/A/bastion"}
  2023-03-23T20:17:38Z	INFO	arecords	DNS A record bastion1 is missing, it will be created	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io", "FQDN": "bastion1.mario01.azuretest.gigantic.io"}
  2023-03-23T20:17:38Z	INFO	arecords	Creating DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "bastion1", "ipv4": [{"ipv4Address":"10.0.0.5"}]}
  2023-03-23T20:17:39Z	INFO	arecords	Successfully created DNS A record	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io", "hostname": "bastion1", "id": "/subscriptions/6b1f6e4a-6d0e-4aa4-9a5a-fbaca65a23b3/resourceGroups/mario01/providers/Microsoft.Network/dnszones/mario01.azuretest.gigantic.io/A/bastion1"}
  2023-03-23T20:17:39Z	INFO	azure-dns-create	Successfully reconciled DNS	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751", "DNSZone": "mario01.azuretest.gigantic.io"}
  2023-03-23T20:17:39Z	INFO	Successfully reconciled AzureCluster DNS zones	{"controller": "azurecluster", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureCluster", "azureCluster": {"name":"mario01","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01", "reconcileID": "9cae1d25-3522-48de-964b-fe037a99d751"}
  2023-03-23T20:17:45Z	INFO	Reconciling Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "2959d377-635b-4f1f-94df-a6d623a438a1"}
  2023-03-23T20:17:45Z	INFO	Successfully reconciled Bastion IP discovery	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-bastion-c3ff8b65-j5vmg","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-bastion-c3ff8b65-j5vmg", "reconcileID": "2959d377-635b-4f1f-94df-a6d623a438a1"}
  2023-03-23T20:20:40Z	INFO	Machine Controller has not yet set OwnerRef	{"controller": "azuremachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "AzureMachine", "azureMachine": {"name":"mario01-control-plane-265fa202-5vjsf","namespace":"org-multi-project"}, "namespace": "org-multi-project", "name": "mario01-control-plane-265fa202-5vjsf", "reconcileID": "2b9d2203-7438-4319-a623-081324f9d5c7"}
  ```

Please note:

in the second commit i've changed the `azuremachine` reconciliation to reduce get-requests towards the k8s api-server as there is no need to create the entire dependency try for each machine if we are only interested in machines with the bastion-host label.