### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,59 +1,55 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.33.0
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
     jobs:
-    - architect/go-build:
-        context: architect
-        name: go-build
-        binary: dns-operator-azure
-        resource_class: large
-        filters:
-          tags:
-            only: /^v.*/
+      - architect/go-build:
+          context: architect
+          name: go-build
+          binary: dns-operator-azure
+          resource_class: large
+          filters:
+            tags:
+              only: /^v.*/
 
-    - architect/push-to-docker:
-        context: architect
-        name: push-dns-operator-azure-to-quay
-        image: "quay.io/giantswarm/dns-operator-azure"
-        username_envar: "QUAY_USERNAME"
-        password_envar: "QUAY_PASSWORD"
-        resource_class: medium
-        requires:
-        - go-build
-        filters:
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
+          requires:
+            - go-build
+          filters:
           # Trigger the job also on git tag.
-          tags:
-            only: /^v.*/
+            tags:
+              only: /^v.*/
 
     # Ensure that for every commit
     # there is an app version in the test catalog.
-    - architect/push-to-app-catalog:
-        context: architect
-        name: push-to-app-catalog
-        app_catalog: "control-plane-catalog"
-        app_catalog_test: "control-plane-test-catalog"
-        chart: "dns-operator-azure"
-        requires:
-        - push-dns-operator-azure-to-quay
-        filters:
+      - architect/push-to-app-catalog:
+          context: architect
+          name: push-to-app-catalog
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: "dns-operator-azure"
+          requires:
+            - push-to-registries
+          filters:
           # Trigger the job also on git tag.
-          tags:
-            only: /^v.*/
+            tags:
+              only: /^v.*/
 
-    - architect/push-to-app-collection:
-        name: capz-app-collection
-        context: "architect"
-        app_name: "dns-operator-azure"
-        app_namespace: "giantswarm"
-        app_collection_repo: "capz-app-collection"
-        requires:
-          - push-to-app-catalog
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v.*/
+      - architect/push-to-app-collection:
+          name: capz-app-collection
+          context: "architect"
+          app_name: "dns-operator-azure"
+          app_namespace: "giantswarm"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - push-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/azure/services/privatedns/client.go
+++ b/azure/services/privatedns/client.go
@@ -148,7 +148,7 @@ func (ac *azureClient) CreateOrUpdateVirtualNetworkLink(ctx context.Context, res
 		ctx,
 		resourceGroupName,
 		zoneName,
-		workloadClusterName+"-dns-"+resourceGroupName+"-vnet-link",
+		virtualNetworkLinkName(workloadClusterName, resourceGroupName),
 		armprivatedns.VirtualNetworkLink{
 			Location: pointer.String(capzazure.Global),
 			Properties: &armprivatedns.VirtualNetworkLinkProperties{
@@ -197,7 +197,7 @@ func (ac *azureClient) ListVirtualNetworkLink(ctx context.Context, resourceGroup
 
 func (ac *azureClient) DeleteVirtualNetworkLink(ctx context.Context, resourceGroupName, zoneName, workloadClusterName string) error {
 
-	poller, err := ac.virtualNetworkLinkClient.BeginDelete(ctx, resourceGroupName, zoneName, workloadClusterName+"-dns-"+resourceGroupName+"-vnet-link", nil)
+	poller, err := ac.virtualNetworkLinkClient.BeginDelete(ctx, resourceGroupName, zoneName, virtualNetworkLinkName(workloadClusterName, resourceGroupName), nil)
 
 	if err != nil {
 		// dns_operator_api_request_errors_total{controller="dns-operator-azure",method="virtualNetworkLinkClient.BeginDelete"}
@@ -287,4 +287,8 @@ func (ac *azureClient) CreateOrUpdateRecordSet(ctx context.Context, resourceGrou
 	}
 
 	return resp.RecordSet, nil
+}
+
+func virtualNetworkLinkName(clusterName, resourceGroupName string) string {
+	return fmt.Sprintf("%s-dns-%s-%s", clusterName, resourceGroupName, "vnet-link")
 }

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -73,7 +73,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	log.V(1).Info("list of all network links", "virtualNetworkLinks", networkLinks)
 
 	operatorGeneratedVirtualNetworkLinkIndex := slices.IndexFunc(networkLinks, func(virtualNetworkLink *armprivatedns.VirtualNetworkLink) bool {
-		return *virtualNetworkLink.Name == *pointer.String(s.scope.ClusterName() + "-dns-" + managementClusterResourceGroup + "-vnet-link")
+		return *virtualNetworkLink.Name == *pointer.String(virtualNetworkLinkName(s.scope.ClusterName(), managementClusterResourceGroup))
 	})
 
 	if operatorGeneratedVirtualNetworkLinkIndex == -1 {

--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.18
 	github.com/coreos/etcd v3.3.13+incompatible => github.com/coreos/etcd v3.3.24+incompatible
 	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
-	golang.org/x/net => golang.org/x/net v0.16.0
+	golang.org/x/net => golang.org/x/net v0.17.0
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.12.0
 
 	// use v0.25 client-go

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
 golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/net v0.16.0 h1:7eBu7KsSvFDtSXUIDbh3aqlK4DPsZ1rByC8PFfBThos=
-golang.org/x/net v0.16.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.5.0 h1:HuArIo48skDwlrvM3sEdHXElYslAMsf3KwRkkW4MC4s=


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!