### PR TITLE
Add seccomp annotation to PSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add seccomp annotation to PSP. 
+
 ## [1.3.2] - 2024-01-22
 
 ### Changed

--- a/helm/dns-operator-azure/templates/psp.yaml
+++ b/helm/dns-operator-azure/templates/psp.yaml
@@ -2,6 +2,8 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: {{ include "resource.psp.name" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}


### PR DESCRIPTION
The app is failing with this in `gaggle` now.


```
    lastUpdateTime: "2024-01-22T11:08:25Z"
    message: 'pods "dns-operator-azure-f74fbb544-" is forbidden: PodSecurityPolicy:
      unable to admit pod: [pod.metadata.annotations[container.seccomp.security.alpha.kubernetes.io/dns-operator-azure]:
      Forbidden: seccomp may not be set spec.securityContext.hostNetwork: Invalid
      value: true: Host network is not allowed to be used spec.containers[0].hostPort:
      Invalid value: 8666: Host port 8666 is not allowed to be used. Allowed ports:
      []]'
```