### PR TITLE
add-toleration-for-unitialized-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add wildcard CNAME record to ingress.basedomain 
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Add node affinity to prefer schedule to `control-plane` nodes.
 
 ## [1.3.4] - 2024-01-22
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
-replace google.golang.org/protobuf v1.31.0 => google.golang.org/protobuf v1.33.0
+replace google.golang.org/protobuf v1.30.0 => google.golang.org/protobuf v1.33.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 
+replace google.golang.org/protobuf v1.31.0 => google.golang.org/protobuf v1.33.0
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/helm/dns-operator-azure/templates/deployment.yaml
+++ b/helm/dns-operator-azure/templates/deployment.yaml
@@ -19,6 +19,14 @@ spec:
       labels:
         {{- include "labels.common" . | nindent 8 }}
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsNonRoot: true
@@ -85,3 +93,9 @@ spec:
             cpu: 250m
             memory: 250Mi
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"


### PR DESCRIPTION
- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
- Add node affinity to prefer schedule to `control-plane` nodes.

towards https://github.com/giantswarm/giantswarm/issues/30433