### PR TITLE
Simplify VNET naming logic

### DIFF
--- a/azure/scope/privatedns.go
+++ b/azure/scope/privatedns.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+
+	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/dns-operator-azure/v2/pkg/errors"
 )
@@ -23,8 +24,6 @@ type PrivateDNSScopeParams struct {
 
 	VirtualNetworkID string
 
-	IsManagementCluster bool
-
 	ManagementClusterAzureIdentity          infrav1.AzureClusterIdentity
 	ManagementClusterServicePrincipalSecret corev1.Secret
 
@@ -38,8 +37,6 @@ type PrivateDNSScope struct {
 	apiServerIP string
 
 	virtualNetworkID string
-
-	isManagementCluster bool
 
 	managementClusterIdentity identity
 
@@ -63,7 +60,6 @@ func NewPrivateDNSScope(_ context.Context, params PrivateDNSScopeParams) (*Priva
 			clusterIdentity: params.ManagementClusterAzureIdentity,
 			secret:          params.ManagementClusterServicePrincipalSecret,
 		},
-		isManagementCluster:   params.IsManagementCluster,
 		managementClusterSpec: params.ManagementClusterSpec,
 		apiServerIP:           params.APIServerIP,
 		virtualNetworkID:      params.VirtualNetworkID,
@@ -86,10 +82,6 @@ func (s *PrivateDNSScope) ManagementClusterVnetID() string {
 
 func (s *PrivateDNSScope) ManagementClusterResourceGroup() string {
 	return s.managementClusterSpec.ResourceGroup
-}
-
-func (s *PrivateDNSScope) IsManagementCluster() bool {
-	return s.isManagementCluster
 }
 
 func (s *PrivateDNSScope) ManagementClusterAzureIdentity() infrav1.AzureClusterIdentity {

--- a/azure/services/privatedns/client.go
+++ b/azure/services/privatedns/client.go
@@ -7,8 +7,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
-	"github.com/giantswarm/microerror"
 	"k8s.io/utils/pointer"
+
+	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/dns-operator-azure/v2/azure/scope"
 	"github.com/giantswarm/dns-operator-azure/v2/pkg/metrics"
@@ -289,9 +290,9 @@ func (ac *azureClient) CreateOrUpdateRecordSet(ctx context.Context, resourceGrou
 	return resp.RecordSet, nil
 }
 
-func virtualNetworkLinkName(clusterName, resourceGroupName string, isManagementCluster bool) string {
-	if isManagementCluster {
-		return fmt.Sprintf("%s-vnet-link", clusterName)
-	}
-	return fmt.Sprintf("%s-dns-%s-%s", clusterName, resourceGroupName, "vnet-link")
+func virtualNetworkLinkName(resourceGroupName string) string {
+	// The name of the linked VNET is "resourceGroupName-vnet"
+	// This is how CAPZ names the VNET links.
+	// We use the same naming convention to avoid conflicts for private MCs.
+	return fmt.Sprintf("%s-vnet-link", resourceGroupName)
 }

--- a/azure/services/privatedns/privatedns.go
+++ b/azure/services/privatedns/privatedns.go
@@ -4,10 +4,11 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
-	"github.com/giantswarm/microerror"
 	"golang.org/x/exp/slices"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/dns-operator-azure/v2/azure"
 	"github.com/giantswarm/dns-operator-azure/v2/azure/scope"
@@ -72,7 +73,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	}
 	log.V(1).Info("list of all network links", "virtualNetworkLinks", networkLinks)
 
-	vnetLinkName := virtualNetworkLinkName(s.scope.ClusterName(), managementClusterResourceGroup, s.scope.IsManagementCluster())
+	vnetLinkName := virtualNetworkLinkName(managementClusterResourceGroup)
 	operatorGeneratedVirtualNetworkLinkIndex := slices.IndexFunc(networkLinks, func(virtualNetworkLink *armprivatedns.VirtualNetworkLink) bool {
 		return *virtualNetworkLink.Name == *pointer.String(vnetLinkName) ||
 			*virtualNetworkLink.ID == s.scope.ManagementClusterClientID()
@@ -139,7 +140,7 @@ func (s *Service) ReconcileDelete(ctx context.Context) error {
 	log.Info("Reconcile DNS deletion", "privateDNSZone", clusterZoneName)
 
 	mcResourceGroup := s.scope.ManagementClusterResourceGroup()
-	vnetLinkName := virtualNetworkLinkName(s.scope.ClusterName(), s.scope.ManagementClusterResourceGroup(), s.scope.IsManagementCluster())
+	vnetLinkName := virtualNetworkLinkName(s.scope.ManagementClusterResourceGroup())
 	if err := s.privateDNSClient.DeleteVirtualNetworkLink(ctx, mcResourceGroup, clusterZoneName, vnetLinkName); err != nil {
 		return microerror.Mask(err)
 	}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -278,7 +278,6 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterScope *i
 		privateParams := azurescope.PrivateDNSScopeParams{
 			BaseDomain:                              r.BaseDomain,
 			ClusterName:                             infraCluster.GetName(),
-			IsManagementCluster:                     managementCluster.Namespace == cluster.Namespace && managementCluster.Name == cluster.Name,
 			ManagementClusterSpec:                   managementCluster.Spec,
 			ManagementClusterAzureIdentity:          *managementClusterAzureIdentity,
 			ManagementClusterServicePrincipalSecret: *managementClusterStaticServicePrincipalSecret,


### PR DESCRIPTION
We don't have a logic to skip MCs for MC-to-WC connection building now. When the MC is a private cluster, dns-operator-azure tries to create the private zone and linked it to the cluster VNET. Its naming is different than the CAPZ's one and it was leading to conflicts. We introduced a check to name MCs differently. It may lead confusions in the future so we decided to simplify the naming and to use the same one for all clusters. 

We don't have  so many WCs right now in production so I will take care of the migration part. 