### PR TITLE
Add a helm switch for PodMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add a helm switch for `PodMonitor`.
+
 ## [2.0.0] - 2024-04-24
 
 ### Added

--- a/helm/dns-operator-azure/templates/podmonitor.yaml
+++ b/helm/dns-operator-azure/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -13,3 +14,4 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+{{ end }}

--- a/helm/dns-operator-azure/values.yaml
+++ b/helm/dns-operator-azure/values.yaml
@@ -44,3 +44,6 @@ secondaryProviders:
 # - kind: openstack
 # - kind: cloud-director
 - kind: vsphere
+
+monitoring:
+  enabled: true


### PR DESCRIPTION
We need to deploy dns-operator-azure to bootstrap cluster while deploying private MCs and PodMonitor CRD doesn't exist there. We need to be able to disable it. 