### PR TITLE
support tagging non-capz resource group via annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for tagging the resource group of the DNS zone for non-CAPZ workload clusters via prefixed annotations on the non-CAPZ workload cluster's Infrastructure Cluster resource.
+
 ## [2.1.1] - 2024-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ CAPZ allows for tagging the resource group of the DNS zone with additional tags 
 For non-CAPZ workload clusters, the resource group of the DNS zone is managed by `dns-operator-azure`.
 The `dns-operator-azure` supports tagging the resource group of the DNS zone via prefixed annotations on the non-CAPZ workload cluster's Infrastructure Cluster resource.
 
-Annotations prefixed by `azure-resource-tag.` will be used to tag the resource group of the DNS zone.
-Note that the prefix `azure-resource-tag.` will be stripped from the annotation key when tagging the resource group.
+Annotations prefixed by `azure-resourcegroup-tag.` will be used to tag the resource group of the DNS zone.
+Note that the prefix `azure-resourcegroup-tag.` will be stripped from the annotation key when tagging the resource group.
 
 ## Expected Behavior
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ We manage non-CAPZ workload clusters in CAPZ MCs too. We call this concept as `m
 Supported non-CAPZ providers:
 - CAPV WCs (Vsphere)
 
+#### Tagging Resource Groups for Non-CAPZ workload clusters
+
+For CAPZ workload clusters, the resource group of the DNS zone is managed by CAPZ.
+CAPZ allows for tagging the resource group of the DNS zone with additional tags set in the `AzureCluster` resource.
+For non-CAPZ workload clusters, the resource group of the DNS zone is managed by `dns-operator-azure`.
+The `dns-operator-azure` supports tagging the resource group of the DNS zone via prefixed annotations on the non-CAPZ workload cluster's Infrastructure Cluster resource.
+
+Annotations prefixed by `azure-resource-tag/` will be used to tag the resource group of the DNS zone.
+Note that the prefix `azure-resource-tag/` will be stripped from the annotation key when tagging the resource group.
+
 ## Expected Behavior
 
 ### Public DNS Zone <wc_name>.<base_domain> in <wc_name> resource group

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ CAPZ allows for tagging the resource group of the DNS zone with additional tags 
 For non-CAPZ workload clusters, the resource group of the DNS zone is managed by `dns-operator-azure`.
 The `dns-operator-azure` supports tagging the resource group of the DNS zone via prefixed annotations on the non-CAPZ workload cluster's Infrastructure Cluster resource.
 
-Annotations prefixed by `azure-resource-tag/` will be used to tag the resource group of the DNS zone.
-Note that the prefix `azure-resource-tag/` will be stripped from the annotation key when tagging the resource group.
+Annotations prefixed by `azure-resource-tag.` will be used to tag the resource group of the DNS zone.
+Note that the prefix `azure-resource-tag.` will be stripped from the annotation key when tagging the resource group.
 
 ## Expected Behavior
 

--- a/azure/scope/dns.go
+++ b/azure/scope/dns.go
@@ -39,6 +39,8 @@ type DNSScopeParams struct {
 	ManagementClusterServicePrincipalSecret corev1.Secret
 
 	ManagementClusterSpec infrav1.AzureClusterSpec
+
+	ResourceTags map[string]*string
 }
 
 // DNSScope defines the basic context for an actuator to operate upon.
@@ -53,6 +55,8 @@ type DNSScope struct {
 	managementClusterIdentity Identity
 
 	managementClusterSpec infrav1.AzureClusterSpec
+
+	resourceTags map[string]*string
 }
 
 type Identity struct {
@@ -87,6 +91,7 @@ func NewDNSScope(_ context.Context, params DNSScopeParams) (*DNSScope, error) {
 			secret:          params.ManagementClusterServicePrincipalSecret,
 		},
 		managementClusterSpec: params.ManagementClusterSpec,
+		resourceTags:          params.ResourceTags,
 	}
 
 	return scope, nil
@@ -122,4 +127,8 @@ func (s *DNSScope) AzureClusterIdentity() infrav1.AzureClusterIdentity {
 
 func (s *DNSScope) AzureClientSecret() string {
 	return string(s.identity.secret.Data[clientSecretKeyName])
+}
+
+func (s *DNSScope) ResourceTags() map[string]*string {
+	return s.resourceTags
 }

--- a/azure/services/dns/resourcegroup.go
+++ b/azure/services/dns/resourcegroup.go
@@ -71,6 +71,7 @@ func (s *Service) updateClusterResourceGroup(ctx context.Context, existingResour
 		)
 
 		existingResourceGroup.Tags = mergeResourceTags(existingResourceGroup.Tags, tags)
+		existingResourceGroup.Properties.ProvisioningState = nil
 		_, err := s.azureClient.CreateOrUpdateResourceGroup(ctx, resourceGroupName, existingResourceGroup)
 		if err != nil {
 			return armresources.ResourceGroup{}, microerror.Mask(err)

--- a/azure/services/dns/resourcegroup.go
+++ b/azure/services/dns/resourcegroup.go
@@ -46,6 +46,9 @@ func (s *Service) createClusterResourceGroup(ctx context.Context) (armresources.
 		Name:     &resourceGroupName,
 		Location: location,
 	}
+	if tags := s.scope.ResourceTags(); tags != nil {
+		resourceGroupParams.Tags = tags
+	}
 
 	resourceGroup, err := s.azureClient.CreateOrUpdateResourceGroup(ctx, resourceGroupName, resourceGroupParams)
 	if err != nil {

--- a/azure/services/dns/resourcegroup_test.go
+++ b/azure/services/dns/resourcegroup_test.go
@@ -1,0 +1,160 @@
+package dns
+
+import (
+	"testing"
+)
+
+func Test_ResourceGroupTags(t *testing.T) {
+	testValue := "test-value"
+	testValue2 := "test-value2"
+
+	testCases := []struct {
+		name    string
+		oldTags map[string]*string
+		newTags map[string]*string
+		equal   bool
+		merged  map[string]*string
+	}{
+		{
+			name: "case0: Equal tags",
+			oldTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			newTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			equal: true,
+			merged: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+		{
+			name:    "case1: Both are nil",
+			oldTags: nil,
+			newTags: nil,
+			equal:   true,
+			merged:  nil,
+		},
+		{
+			name: "case2: Different tags",
+			oldTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			newTags: map[string]*string{
+				"test-key1": &testValue,
+			},
+			equal: false,
+			merged: map[string]*string{
+				"test-key":  &testValue,
+				"test-key1": &testValue,
+			},
+		},
+		{
+			name: "case3: Different values",
+			oldTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			newTags: map[string]*string{
+				"test-key": &testValue2,
+			},
+			equal: false,
+			merged: map[string]*string{
+				"test-key": &testValue2,
+			},
+		},
+		{
+			name:    "case4: Old tags are nil",
+			oldTags: nil,
+			newTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			equal: false,
+			merged: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+		{
+			name: "case5: New tags are nil",
+			oldTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			newTags: nil,
+			equal:   false,
+			merged: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+		{
+			name:    "case6: Old tags are empty",
+			oldTags: map[string]*string{},
+			newTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			equal: false,
+			merged: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+		{
+			name: "case7: New tags are empty",
+			oldTags: map[string]*string{
+				"test-key": &testValue,
+			},
+			newTags: map[string]*string{},
+			equal:   false,
+			merged: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+		{
+			name: "case8: Old tags contains various tags",
+			oldTags: map[string]*string{
+				"test-key":  &testValue,
+				"test-key1": &testValue,
+			},
+			newTags: map[string]*string{
+				"test-key": &testValue2,
+			},
+			equal: false,
+			merged: map[string]*string{
+				"test-key":  &testValue2,
+				"test-key1": &testValue,
+			},
+		},
+		{
+			name:    "case9: Old tags are nil and new tags are empty",
+			oldTags: nil,
+			newTags: map[string]*string{},
+			equal:   true,
+			merged:  map[string]*string{},
+		},
+		{
+			name:    "case10: Old tags are empty and new tags are nil",
+			oldTags: map[string]*string{},
+			newTags: nil,
+			equal:   true,
+			merged:  map[string]*string{},
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			equal := resourceGroupTagsEqual(tc.oldTags, tc.newTags)
+			if equal != tc.equal {
+				t.Fatalf("expected %v, got %v", tc.equal, equal)
+			}
+
+			merged := mergeResourceTags(tc.oldTags, tc.newTags)
+			if len(merged) != len(tc.merged) {
+				t.Fatalf("expected %v, got %v", tc.merged, merged)
+			}
+
+			for key, value := range tc.merged {
+				if *merged[key] != *value {
+					t.Fatalf("expected %v, got %v", *value, *merged[key])
+				}
+			}
+		})
+	}
+}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -335,6 +335,7 @@ func (r *ClusterReconciler) getDnsServiceForPublicRecords(ctx context.Context, l
 			SubscriptionID: r.BaseZoneSubscriptionID,
 			TenantID:       r.BaseZoneTenantID,
 		},
+		ResourceTags: infracluster.GetResourceTagsFromInfraClusterAnnotations(clusterScope.InfraClusterAnnotations()),
 	}
 
 	dnsScope, err := azurescope.NewDNSScope(ctx, params)

--- a/pkg/infracluster/annotation.go
+++ b/pkg/infracluster/annotation.go
@@ -17,7 +17,8 @@ func GetResourceTagsFromInfraClusterAnnotations(annotations map[string]string) m
 	for key, value := range annotations {
 		if strings.HasPrefix(key, ResourceTagNamePrefix) {
 			tagKey := strings.TrimPrefix(key, ResourceTagNamePrefix)
-			tags[tagKey] = &value
+			tagValue := value
+			tags[tagKey] = &tagValue
 		}
 	}
 	if len(tags) == 0 {

--- a/pkg/infracluster/annotation.go
+++ b/pkg/infracluster/annotation.go
@@ -1,0 +1,27 @@
+package infracluster
+
+import "strings"
+
+const (
+	ResourceTagNamePrefix = "azure-resource-tag/"
+)
+
+func GetResourceTagsFromInfraClusterAnnotations(annotations map[string]string) map[string]*string {
+	if annotations == nil {
+		return nil
+	}
+	if len(annotations) == 0 {
+		return nil
+	}
+	tags := make(map[string]*string)
+	for key, value := range annotations {
+		if strings.HasPrefix(key, ResourceTagNamePrefix) {
+			tagKey := strings.TrimPrefix(key, ResourceTagNamePrefix)
+			tags[tagKey] = &value
+		}
+	}
+	if len(tags) == 0 {
+		return nil
+	}
+	return tags
+}

--- a/pkg/infracluster/annotation.go
+++ b/pkg/infracluster/annotation.go
@@ -3,7 +3,7 @@ package infracluster
 import "strings"
 
 const (
-	ResourceTagNamePrefix = "azure-resource-tag."
+	ResourceTagNamePrefix = "azure-resourcegroup-tag."
 )
 
 func GetResourceTagsFromInfraClusterAnnotations(annotations map[string]string) map[string]*string {

--- a/pkg/infracluster/annotation.go
+++ b/pkg/infracluster/annotation.go
@@ -3,7 +3,7 @@ package infracluster
 import "strings"
 
 const (
-	ResourceTagNamePrefix = "azure-resource-tag/"
+	ResourceTagNamePrefix = "azure-resource-tag."
 )
 
 func GetResourceTagsFromInfraClusterAnnotations(annotations map[string]string) map[string]*string {

--- a/pkg/infracluster/annotation_test.go
+++ b/pkg/infracluster/annotation_test.go
@@ -22,7 +22,7 @@ func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
 			infraCluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"azure-resource-tag.test-key": testValue,
+						"azure-resourcegroup-tag.test-key": testValue,
 					},
 				},
 			},
@@ -35,8 +35,8 @@ func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
 			infraCluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"azure-resource-tag.test-key":  testValue,
-						"azure-resource-tag.test-key1": testValue,
+						"azure-resourcegroup-tag.test-key":  testValue,
+						"azure-resourcegroup-tag.test-key1": testValue,
 					},
 				},
 			},
@@ -77,8 +77,8 @@ func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
 			infraCluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"azure-resource-tag.test-key": testValue,
-						"test-key":                    testValue,
+						"azure-resourcegroup-tag.test-key": testValue,
+						"test-key":                         testValue,
 					},
 				},
 			},

--- a/pkg/infracluster/annotation_test.go
+++ b/pkg/infracluster/annotation_test.go
@@ -22,7 +22,7 @@ func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
 			infraCluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"azure-resource-tag/test-key": testValue,
+						"azure-resource-tag.test-key": testValue,
 					},
 				},
 			},
@@ -35,8 +35,8 @@ func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
 			infraCluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"azure-resource-tag/test-key":  testValue,
-						"azure-resource-tag/test-key1": testValue,
+						"azure-resource-tag.test-key":  testValue,
+						"azure-resource-tag.test-key1": testValue,
 					},
 				},
 			},
@@ -77,7 +77,7 @@ func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
 			infraCluster: &infrav1.AzureCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"azure-resource-tag/test-key": testValue,
+						"azure-resource-tag.test-key": testValue,
 						"test-key":                    testValue,
 					},
 				},

--- a/pkg/infracluster/annotation_test.go
+++ b/pkg/infracluster/annotation_test.go
@@ -1,0 +1,116 @@
+package infracluster
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+)
+
+func Test_GetResourceTagsFromInfraClusterAnnotation(t *testing.T) {
+	testValue := "test-value"
+
+	testCases := []struct {
+		name         string
+		infraCluster runtime.Object
+		expectedTags map[string]*string
+	}{
+		{
+			name: "case0: Get resource tag from infra cluster annotations",
+			infraCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"azure-resource-tag/test-key": testValue,
+					},
+				},
+			},
+			expectedTags: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+		{
+			name: "case1: Get resource tag from infra cluster annotations with multiple tags",
+			infraCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"azure-resource-tag/test-key":  testValue,
+						"azure-resource-tag/test-key1": testValue,
+					},
+				},
+			},
+			expectedTags: map[string]*string{
+				"test-key":  &testValue,
+				"test-key1": &testValue,
+			},
+		},
+		{
+			name: "case2: Get resource tag from infra cluster annotations with no tags",
+			infraCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expectedTags: nil,
+		},
+		{
+			name: "case3: Get resource tag from infra cluster annotations with no annotations",
+			infraCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedTags: nil,
+		},
+		{
+			name: "case4: Get resource tag from infra cluster annotations with unprefixed tags",
+			infraCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"test-key": testValue,
+					},
+				},
+			},
+			expectedTags: nil,
+		},
+		{
+			name: "case5: Get resource tag from infra cluster annotations with some unprefixed tags",
+			infraCluster: &infrav1.AzureCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"azure-resource-tag/test-key": testValue,
+						"test-key":                    testValue,
+					},
+				},
+			},
+			expectedTags: map[string]*string{
+				"test-key": &testValue,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			infraClusterObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.infraCluster)
+			if err != nil {
+				t.Fatal(err)
+			}
+			scope := Scope{
+				InfraCluster: &unstructured.Unstructured{Object: infraClusterObj},
+			}
+			tags := GetResourceTagsFromInfraClusterAnnotations(scope.InfraClusterAnnotations())
+			if len(tags) != len(tc.expectedTags) {
+				t.Fatalf("expected %d tags, got %d", len(tc.expectedTags), len(tags))
+			}
+
+			for key, value := range tc.expectedTags {
+				if tags[key] == nil {
+					t.Fatalf("expected tag %s not found", key)
+				}
+				if *tags[key] != *value {
+					t.Fatalf("expected tag %s value %s, got %s", key, *value, *tags[key])
+				}
+			}
+		})
+	}
+}

--- a/pkg/infracluster/scope.go
+++ b/pkg/infracluster/scope.go
@@ -142,6 +142,10 @@ func (s *Scope) InfraClusterIdentity(ctx context.Context) (*infrav1.AzureCluster
 	return s.ManagementClusterIdentity(ctx)
 }
 
+func (s *Scope) InfraClusterAnnotations() map[string]string {
+	return s.InfraCluster.GetAnnotations()
+}
+
 func (s *Scope) ClusterK8sClient(ctx context.Context) (client.Client, error) {
 	if s.clusterK8sClient == nil {
 		var err error


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/31444

For CAPZ workload clusters, the resource group of the DNS zone is managed by CAPZ and it's possible to add additional tags to it using the cluster chart.
For non-CAPZ workload clusters such functionality does not exist since the resource group is created by the dns operator instead.
This leads to some issues where customers expect certain tags on the resource group to be present.

This PR supports tagging the resource group based on annotations on the infracluster object.