### PR TITLE
Set status annotation when AzureCluster reconciler completes

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -209,6 +209,8 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterScope *i
 		return reconcile.Result{}, microerror.Mask(err)
 	}
 
+	clusterScope.SetStatusAnnotation()
+
 	logger.Info("Successfully reconciled InfraCluster DNS zones")
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/infracluster/common_patcher.go
+++ b/pkg/infracluster/common_patcher.go
@@ -10,6 +10,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	DnsOperatorStatusAnnotation string = "dns-operator-azure.giantswarm.io/status"
+)
+
 type CommonPatcherParams struct {
 	ClientID       string
 	SubscriptionID string
@@ -79,6 +83,15 @@ func (s *CommonPatcher) APIServerPublicIP() *infrav1.PublicIPSpec {
 	return &infrav1.PublicIPSpec{
 		Name: s.ip.String(),
 	}
+}
+
+func (s *CommonPatcher) SetAnnotation(key, value string) {
+	annotations := s.InfraCluster.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[key] = value
+	s.InfraCluster.SetAnnotations(annotations)
 }
 
 func (s *CommonPatcher) Close(ctx context.Context) error {

--- a/pkg/infracluster/scope.go
+++ b/pkg/infracluster/scope.go
@@ -40,6 +40,7 @@ type Patcher interface {
 	IsAPIServerPrivate() bool
 	APIServerPrivateIP() string
 	APIServerPublicIP() *infrav1.PublicIPSpec
+	SetAnnotation(key, value string)
 	Close(ctx context.Context) error
 }
 
@@ -146,6 +147,10 @@ func (s *Scope) InfraClusterIdentity(ctx context.Context) (*infrav1.AzureCluster
 
 func (s *Scope) InfraClusterAnnotations() map[string]string {
 	return s.InfraCluster.GetAnnotations()
+}
+
+func (s *Scope) SetStatusAnnotation() {
+	s.Patcher.SetAnnotation(DnsOperatorStatusAnnotation, "done")
 }
 
 func (s *Scope) ClusterK8sClient(ctx context.Context) (client.Client, error) {


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/35240. Defining an easy signal to know when the reconciler is done.

Tested on `glean`.