### PR TITLE
Create A records Envoy Gateway

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,1 @@
-CVE-2025-47913 until=2026-01-21 # golang.org/x/crypto@v0.41.0
-CVE-2025-47914 until=2026-01-21 # golang.org/x/crypto@v0.41.0
-CVE-2025-58181 until=2026-01-21 # golang.org/x/crypto@v0.41.0
+CVE-2026-39883 until=2026-10-10 # golang/go.opentelemetry.io/otel/sdk@v1.40.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Create A records for services annotated with `giantswarm.io/external-dns: managed` in `envoy-gateway-system`, deriving the record name from `external-dns.alpha.kubernetes.io/hostname` and the IP from the service's LoadBalancer status.
+- Read the ingress A record name from the `external-dns.alpha.kubernetes.io/hostname` annotation on the nginx ingress service instead of using the hardcoded name `ingress`.
+
 ### Changed
 
 - Move to CAPI v1beta2 API.

--- a/azure/services/dns/arecords.go
+++ b/azure/services/dns/arecords.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	armnetworkv4 "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
@@ -31,9 +32,15 @@ const (
 
 	apiRecordTTL     = 300
 	ingressRecordTTL = 300
+	gatewayRecordTTL = 300
 
 	ingressServiceSelector = "app.kubernetes.io/name in (ingress-nginx,nginx-ingress-controller)"
 	ingressAppNamespace    = "kube-system"
+
+	gatewayNamespace              = "envoy-gateway-system"
+	externalDNSManagedAnnotation  = "giantswarm.io/external-dns"
+	externalDNSManagedValue       = "managed"
+	externalDNSHostnameAnnotation = "external-dns.alpha.kubernetes.io/hostname"
 )
 
 func (s *Service) updateARecords(ctx context.Context, currentRecordSets []*armdns.RecordSet) error {
@@ -196,6 +203,7 @@ func (s *Service) getDesiredARecords(ctx context.Context) ([]*armdns.RecordSet, 
 	}
 
 	if !s.scope.IsAzureCluster() {
+		// ingress: fixed A record for the nginx ingress controller.
 		ingressIP, err := s.getIngressIP(ctx)
 		if err != nil {
 			return nil, microerror.Mask(err)
@@ -213,6 +221,13 @@ func (s *Service) getDesiredARecords(ctx context.Context) ([]*armdns.RecordSet, 
 				},
 			})
 		}
+
+		// gateway: one A record per annotated service in envoy-gateway-system.
+		gatewayRecords, err := s.getGatewayARecords(ctx)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		armdnsRecordSet = append(armdnsRecordSet, gatewayRecords...)
 	}
 
 	return armdnsRecordSet, nil
@@ -286,4 +301,49 @@ func (s *Service) getIngressIP(ctx context.Context) (string, error) {
 	}
 
 	return icServiceIP, nil
+}
+
+func (s *Service) getGatewayARecords(ctx context.Context) ([]*armdns.RecordSet, error) {
+	k8sClient, err := s.scope.ClusterK8sClient(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var services corev1.ServiceList
+	if err = k8sClient.List(ctx, &services, kubeclient.InNamespace(gatewayNamespace)); err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clusterZone := s.scope.ClusterDomain()
+	var recordSets []*armdns.RecordSet
+
+	for _, svc := range services.Items {
+		if svc.Annotations[externalDNSManagedAnnotation] != externalDNSManagedValue {
+			continue
+		}
+		hostname, ok := svc.Annotations[externalDNSHostnameAnnotation]
+		if !ok || hostname == "" {
+			continue
+		}
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		if len(svc.Status.LoadBalancer.Ingress) < 1 || svc.Status.LoadBalancer.Ingress[0].IP == "" {
+			continue
+		}
+
+		recordName := strings.TrimSuffix(hostname, "."+clusterZone)
+		recordSets = append(recordSets, &armdns.RecordSet{
+			Name: pointer.String(recordName),
+			Type: pointer.String(string(armdns.RecordTypeA)),
+			Properties: &armdns.RecordSetProperties{
+				TTL: pointer.Int64(gatewayRecordTTL),
+				ARecords: []*armdns.ARecord{
+					{IPv4Address: pointer.String(svc.Status.LoadBalancer.Ingress[0].IP)},
+				},
+			},
+		})
+	}
+
+	return recordSets, nil
 }

--- a/azure/services/dns/arecords.go
+++ b/azure/services/dns/arecords.go
@@ -28,7 +28,6 @@ import (
 const (
 	apiRecordName       = "api"
 	apiserverRecordName = "apiserver"
-	ingressRecordName   = "ingress"
 
 	apiRecordTTL     = 300
 	ingressRecordTTL = 300
@@ -203,23 +202,13 @@ func (s *Service) getDesiredARecords(ctx context.Context) ([]*armdns.RecordSet, 
 	}
 
 	if !s.scope.IsAzureCluster() {
-		// ingress: fixed A record for the nginx ingress controller.
-		ingressIP, err := s.getIngressIP(ctx)
+		// ingress: A record for the nginx ingress controller, name read from external-dns annotation.
+		ingressRecord, err := s.getIngressARecord(ctx)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
-		// TODO: Should the reconciliation fail in case the ingress IP is empty?
-		if ingressIP != "" {
-			armdnsRecordSet = append(armdnsRecordSet, &armdns.RecordSet{
-				Name: pointer.String(ingressRecordName),
-				Type: pointer.String(string(armdns.RecordTypeA)),
-				Properties: &armdns.RecordSetProperties{
-					TTL: pointer.Int64(ingressRecordTTL),
-					ARecords: []*armdns.ARecord{
-						{IPv4Address: pointer.String(ingressIP)},
-					},
-				},
-			})
+		if ingressRecord != nil {
+			armdnsRecordSet = append(armdnsRecordSet, ingressRecord)
 		}
 
 		// gateway: one A record per annotated service in envoy-gateway-system.
@@ -267,40 +256,52 @@ func (s *Service) getIPAddressForPublicDNS(ctx context.Context) (string, error) 
 	return s.scope.Patcher.APIServerPublicIP().Name, nil
 }
 
-func (s *Service) getIngressIP(ctx context.Context) (string, error) {
+func (s *Service) getIngressARecord(ctx context.Context) (*armdns.RecordSet, error) {
 	k8sClient, err := s.scope.ClusterK8sClient(ctx)
 	if err != nil {
-		return "", microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
 
 	var icServices corev1.ServiceList
-
 	err = k8sClient.List(ctx, &icServices,
 		kubeclient.InNamespace(ingressAppNamespace),
 		&kubeclient.ListOptions{Raw: &metav1.ListOptions{LabelSelector: ingressServiceSelector}},
 	)
-
 	if err != nil {
-		return "", microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
 
-	var icServiceIP string
+	clusterZone := s.scope.ClusterDomain()
 
 	for _, icService := range icServices.Items {
-		if icService.Spec.Type == corev1.ServiceTypeLoadBalancer {
-			if icServiceIP != "" {
-				return "", microerror.Mask(tooManyICServicesError)
-			}
-
-			if len(icService.Status.LoadBalancer.Ingress) < 1 || icService.Status.LoadBalancer.Ingress[0].IP == "" {
-				return "", microerror.Mask(ingressNotReadyError)
-			}
-
-			icServiceIP = icService.Status.LoadBalancer.Ingress[0].IP
+		if icService.Annotations[externalDNSManagedAnnotation] != externalDNSManagedValue {
+			continue
 		}
+		hostname, ok := icService.Annotations[externalDNSHostnameAnnotation]
+		if !ok || hostname == "" {
+			continue
+		}
+		if icService.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		if len(icService.Status.LoadBalancer.Ingress) < 1 || icService.Status.LoadBalancer.Ingress[0].IP == "" {
+			return nil, microerror.Mask(ingressNotReadyError)
+		}
+
+		recordName := strings.TrimSuffix(hostname, "."+clusterZone)
+		return &armdns.RecordSet{
+			Name: pointer.String(recordName),
+			Type: pointer.String(string(armdns.RecordTypeA)),
+			Properties: &armdns.RecordSetProperties{
+				TTL: pointer.Int64(ingressRecordTTL),
+				ARecords: []*armdns.ARecord{
+					{IPv4Address: pointer.String(icService.Status.LoadBalancer.Ingress[0].IP)},
+				},
+			},
+		}, nil
 	}
 
-	return icServiceIP, nil
+	return nil, nil
 }
 
 func (s *Service) getGatewayARecords(ctx context.Context) ([]*armdns.RecordSet, error) {

--- a/azure/services/dns/arecords_test.go
+++ b/azure/services/dns/arecords_test.go
@@ -26,6 +26,8 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/giantswarm/microerror"
+
 	"github.com/giantswarm/dns-operator-azure/v3/azure/scope"
 	"github.com/giantswarm/dns-operator-azure/v3/pkg/infracluster"
 )
@@ -715,6 +717,215 @@ func TestService_getGatewayARecords(t *testing.T) {
 				gotJSON, _ := json.Marshal(got)
 				wantJSON, _ := json.Marshal(tt.want)
 				t.Errorf("getGatewayARecords() = %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestService_getIngressARecord(t *testing.T) {
+	// Cluster domain for the test service: test-cluster.basedomain.io
+	ctx := context.TODO()
+
+	// ingressLabels satisfies the ingressServiceSelector label selector.
+	ingressLabels := map[string]string{"app.kubernetes.io/name": "ingress-nginx"}
+
+	tests := []struct {
+		name        string
+		services    []*corev1.Service
+		want        *armdns.RecordSet
+		wantErrKind string
+	}{
+		{
+			name:     "returns nil when no services in namespace",
+			services: nil,
+			want:     nil,
+		},
+		{
+			name: "skips service without managed annotation",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips service with wrong managed annotation value",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  "not-managed",
+							externalDNSHostnameAnnotation: "ingress.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips service without hostname annotation",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation: externalDNSManagedValue,
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips non-LoadBalancer service",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "ingress.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "returns ingressNotReadyError when LB has no IP yet",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "ingress.test-cluster.basedomain.io",
+						},
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+			},
+			want:        nil,
+			wantErrKind: ingressNotReadyError.Kind,
+		},
+		{
+			name: "creates A record with name from hostname annotation",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "ingress.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: &armdns.RecordSet{
+				Name: pointer.String("ingress"),
+				Type: pointer.String("A"),
+				Properties: &armdns.RecordSetProperties{
+					TTL:      pointer.Int64(ingressRecordTTL),
+					ARecords: []*armdns.ARecord{{IPv4Address: pointer.String("1.2.3.4")}},
+				},
+			},
+		},
+		{
+			name: "record name uses full prefix when hostname has multiple labels",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ingress-nginx",
+						Namespace: ingressAppNamespace,
+						Labels:    ingressLabels,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "my-ingress.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "5.6.7.8"}},
+						},
+					},
+				},
+			},
+			want: &armdns.RecordSet{
+				Name: pointer.String("my-ingress"),
+				Type: pointer.String("A"),
+				Properties: &armdns.RecordSetProperties{
+					TTL:      pointer.Int64(ingressRecordTTL),
+					ARecords: []*armdns.ARecord{{IPv4Address: pointer.String("5.6.7.8")}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newGatewayTestService(t, ctx, tt.services)
+
+			got, err := svc.getIngressARecord(ctx)
+			if tt.wantErrKind != "" {
+				if err == nil {
+					t.Fatalf("expected error with kind %q, got nil", tt.wantErrKind)
+				}
+				if cause, ok := microerror.Cause(err).(*microerror.Error); !ok || cause.Kind != tt.wantErrKind {
+					t.Fatalf("expected error kind %q, got %v", tt.wantErrKind, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				gotJSON, _ := json.Marshal(got)
+				wantJSON, _ := json.Marshal(tt.want)
+				t.Errorf("getIngressARecord() = %s, want %s", gotJSON, wantJSON)
 			}
 		})
 	}

--- a/azure/services/dns/arecords_test.go
+++ b/azure/services/dns/arecords_test.go
@@ -263,6 +263,11 @@ func TestService_calculateMissingARecords(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			// inject empty workload cluster client so getGatewayARecords finds no services
+			dnsService.scope.SetClusterK8sClient(
+				fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+			)
+
 			got, err := dnsService.calculateMissingARecords(tt.args.ctx, tt.args.logger, tt.args.currentRecordSets)
 			if err != nil {
 				t.Errorf("Service.calculateMissingARecords() error = %v", err)
@@ -278,6 +283,438 @@ func TestService_calculateMissingARecords(t *testing.T) {
 					t.Fatal(err)
 				}
 				t.Errorf("Service.calculateMissingARecords() = %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+// newGatewayTestService builds a DNS Service for gateway tests. The provided
+// wcServices are loaded into a fake workload cluster client and injected into
+// the service scope, bypassing kubeconfig resolution.
+func newGatewayTestService(t *testing.T, ctx context.Context, wcServices []*corev1.Service) *Service {
+	t.Helper()
+
+	cluster := &capi.Cluster{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: capi.ClusterSpec{
+			ControlPlaneEndpoint: capi.APIEndpoint{
+				Host: "api-server.mydomain.io",
+				Port: 6443,
+			},
+			InfrastructureRef: capi.ContractVersionedObjectReference{
+				Name: "test-cluster",
+			},
+		},
+	}
+
+	identity := &infrav1.AzureClusterIdentity{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fake-identity",
+			Namespace: "default",
+		},
+		Spec: infrav1.AzureClusterIdentitySpec{
+			Type:     infrav1.ServicePrincipal,
+			ClientID: fakeClientID,
+			TenantID: fakeTenantID,
+			ClientSecret: corev1.SecretReference{
+				Name:      "fake-identity-secret",
+				Namespace: "default",
+			},
+		},
+	}
+	identitySecret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "fake-identity-secret",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{"clientSecret": []byte("fooSecret")},
+	}
+
+	azureCluster := &infrav1.AzureCluster{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "AzureCluster",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+		Spec: infrav1.AzureClusterSpec{
+			ResourceGroup: "test-rg",
+			AzureClusterClassSpec: infrav1.AzureClusterClassSpec{
+				IdentityRef: &corev1.ObjectReference{
+					Kind: infrav1.AzureClusterIdentityKind,
+					Name: "fake-identity",
+				},
+				SubscriptionID: uuid.New().String(),
+			},
+			ControlPlaneEndpoint: v1beta1.APIEndpoint{
+				Host: "api-server.mydomain.io",
+				Port: 6443,
+			},
+		},
+	}
+
+	schemeBuilder := runtime.SchemeBuilder{
+		capi.AddToScheme,
+		infrav1.AddToScheme,
+	}
+	if err := schemeBuilder.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	mcClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithRuntimeObjects(azureCluster, cluster, identity, identitySecret).
+		Build()
+
+	infraClusterObj := &unstructured.Unstructured{}
+	infraClusterObj.SetGroupVersionKind(azureCluster.GroupVersionKind())
+	if err := mcClient.Get(ctx, k8sclient.ObjectKey{Name: azureCluster.Name, Namespace: azureCluster.Namespace}, infraClusterObj); err != nil {
+		t.Fatal(err)
+	}
+
+	clusterScope, err := capzscope.NewClusterScope(ctx, capzscope.ClusterScopeParams{
+		Client:          mcClient,
+		Cluster:         cluster,
+		AzureCluster:    azureCluster,
+		CredentialCache: azure.NewCredentialCache(),
+		Timeouts:        reconciler.Timeouts{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	infraClusterScope, err := infracluster.NewScope(ctx, infracluster.ScopeParams{
+		Client:       mcClient,
+		Cluster:      cluster,
+		InfraCluster: infraClusterObj,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	infraClusterScope.Patcher = clusterScope
+
+	dnsScope, err := scope.NewDNSScope(ctx, scope.DNSScopeParams{
+		BaseZoneCredentials: scope.BaseZoneCredentials{
+			ClientID:       uuid.New().String(),
+			ClientSecret:   uuid.New().String(),
+			TenantID:       uuid.New().String(),
+			SubscriptionID: uuid.New().String(),
+		},
+		BaseDomain:              "basedomain.io",
+		BaseDomainResourceGroup: "basedomain_resource_group",
+		ClusterScope:            infraClusterScope,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	publicIPsService, err := publicips.New(clusterScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dnsService, err := New(*dnsScope, publicIPsService)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a dedicated scheme for the workload cluster client with only core types.
+	wcScheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(wcScheme); err != nil {
+		t.Fatal(err)
+	}
+	wcClientBuilder := fakeclient.NewClientBuilder().WithScheme(wcScheme)
+	for _, svc := range wcServices {
+		wcClientBuilder = wcClientBuilder.WithObjects(svc)
+	}
+	dnsService.scope.SetClusterK8sClient(wcClientBuilder.Build())
+
+	return dnsService
+}
+
+func TestService_getGatewayARecords(t *testing.T) {
+	// Cluster domain for the test service: test-cluster.basedomain.io
+	ctx := context.TODO()
+
+	tests := []struct {
+		name     string
+		services []*corev1.Service
+		want     []*armdns.RecordSet
+	}{
+		{
+			name:     "returns nil when namespace has no services",
+			services: nil,
+			want:     nil,
+		},
+		{
+			name: "skips service without annotations",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: gatewayNamespace,
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips service with wrong managed annotation value",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  "not-managed",
+							externalDNSHostnameAnnotation: "gw.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips service without hostname annotation",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation: externalDNSManagedValue,
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips non-LoadBalancer service",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "gw.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "skips LoadBalancer service with no IP assigned yet",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "gw.test-cluster.basedomain.io",
+						},
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "creates A record for valid gateway service",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "gw.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: []*armdns.RecordSet{
+				{
+					Name: pointer.String("gw"),
+					Type: pointer.String("A"),
+					Properties: &armdns.RecordSetProperties{
+						TTL:      pointer.Int64(gatewayRecordTTL),
+						ARecords: []*armdns.ARecord{{IPv4Address: pointer.String("1.2.3.4")}},
+					},
+				},
+			},
+		},
+		{
+			name: "creates A records for multiple valid gateway services",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway-a",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "app1.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway-b",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "app2.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "5.6.7.8"}},
+						},
+					},
+				},
+			},
+			want: []*armdns.RecordSet{
+				{
+					Name: pointer.String("app1"),
+					Type: pointer.String("A"),
+					Properties: &armdns.RecordSetProperties{
+						TTL:      pointer.Int64(gatewayRecordTTL),
+						ARecords: []*armdns.ARecord{{IPv4Address: pointer.String("1.2.3.4")}},
+					},
+				},
+				{
+					Name: pointer.String("app2"),
+					Type: pointer.String("A"),
+					Properties: &armdns.RecordSetProperties{
+						TTL:      pointer.Int64(gatewayRecordTTL),
+						ARecords: []*armdns.ARecord{{IPv4Address: pointer.String("5.6.7.8")}},
+					},
+				},
+			},
+		},
+		{
+			name: "ignores services in other namespaces",
+			services: []*corev1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway",
+						Namespace: "kube-system",
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "gw.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "mixed valid and invalid services only includes valid ones",
+			services: []*corev1.Service{
+				{
+					// valid
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway-valid",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "gw.test-cluster.basedomain.io",
+						},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+						},
+					},
+				},
+				{
+					// invalid: no IP
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "envoy-gateway-no-ip",
+						Namespace: gatewayNamespace,
+						Annotations: map[string]string{
+							externalDNSManagedAnnotation:  externalDNSManagedValue,
+							externalDNSHostnameAnnotation: "gw2.test-cluster.basedomain.io",
+						},
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+			},
+			want: []*armdns.RecordSet{
+				{
+					Name: pointer.String("gw"),
+					Type: pointer.String("A"),
+					Properties: &armdns.RecordSetProperties{
+						TTL:      pointer.Int64(gatewayRecordTTL),
+						ARecords: []*armdns.ARecord{{IPv4Address: pointer.String("1.2.3.4")}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newGatewayTestService(t, ctx, tt.services)
+
+			got, err := svc.getGatewayARecords(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				gotJSON, _ := json.Marshal(got)
+				wantJSON, _ := json.Marshal(tt.want)
+				t.Errorf("getGatewayARecords() = %s, want %s", gotJSON, wantJSON)
 			}
 		})
 	}

--- a/pkg/infracluster/scope.go
+++ b/pkg/infracluster/scope.go
@@ -159,6 +159,12 @@ func (s *Scope) ClusterK8sClient(ctx context.Context) (client.Client, error) {
 	return s.clusterK8sClient, nil
 }
 
+// SetClusterK8sClient sets the workload cluster k8s client directly, bypassing
+// kubeconfig resolution. Used in tests to inject a fake client.
+func (s *Scope) SetClusterK8sClient(c client.Client) {
+	s.clusterK8sClient = c
+}
+
 func NewScope(ctx context.Context, params ScopeParams) (*Scope, error) {
 	var err error
 


### PR DESCRIPTION
## What this PR does

Extends the operator to create A records for services that expose workload cluster endpoints via annotations, rather than relying on hardcoded record names or namespaces.

### Gateway API support (envoy-gateway-system)

For services in the `envoy-gateway-system` namespace, the operator now discovers and creates A records dynamically. A service is picked up when it has both:

- `giantswarm.io/external-dns: managed`
- `external-dns.alpha.kubernetes.io/hostname: <fqdn>`

The record name is derived by stripping the cluster zone suffix from the hostname annotation. One A record is created per annotated LoadBalancer service.

### Ingress record name from annotation

Previously the ingress A record was hardcoded to the name `ingress`, reading only the IP from the nginx-ingress LoadBalancer status. The record name is now also read from the `external-dns.alpha.kubernetes.io/hostname` annotation on the ingress-nginx service (same annotation-driven approach as the gateway records above). The service discovery (label selector in `kube-system`) is unchanged.