### PR TITLE
fix: split china registry push into separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ workflows:
       - architect/push-to-registries:
           name: push-to-registries
           context: architect
+          # Skip the trans-Pacific Aliyun push in-line; the sync-china-registry
+          # job below mirrors gsoci -> Aliyun from an in-China runner in parallel.
+          split-china-push: true
           requires:
             - go-build
           filters:
@@ -44,3 +47,17 @@ workflows:
                 - master
             tags:
               only: /^v.*/
+
+      # Mirror gsoci -> Aliyun via the in-China giantswarm/galaxy-runner, off the
+      # push-to-registries critical path. Tag builds only (dev images don't push
+      # to Aliyun).
+      - architect/sync-china-registry:
+          context: architect
+          name: sync-china-registry
+          requires:
+            - push-to-registries
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI: offload the Aliyun (China) image push to a parallel `sync-china-registry` job via `split-china-push`.
+
 ## [2.6.0] - 2026-07-10
 
 ### Added


### PR DESCRIPTION
Push to China can take a very long time, blocking the whole build. This PR takes inspiration from Muster's CI (https://github.com/giantswarm/muster/blob/main/.circleci/workflows.yml) to have a specific job that pushes to China.